### PR TITLE
Fixed a compile error with gcc 7.2

### DIFF
--- a/keyboards/k_type/matrix.c
+++ b/keyboards/k_type/matrix.c
@@ -42,8 +42,8 @@ void matrix_init(void)
     palSetPadMode(GPIOD, 1,   PAL_MODE_OUTPUT_PUSHPULL);
     palSetPadMode(GPIOD, 4,   PAL_MODE_OUTPUT_PUSHPULL);
 
-    memset(matrix, 0, MATRIX_ROWS);
-    memset(matrix_debouncing, 0, MATRIX_ROWS);
+    memset(matrix, 0, MATRIX_ROWS * sizeof(matrix_row_t));
+    memset(matrix_debouncing, 0, MATRIX_ROWS * sizeof(matrix_row_t));
 }
 
 uint8_t matrix_scan(void)


### PR DESCRIPTION
gcc 7.2 emits a warning when memset is used without a multiplication with the size of an object and due to `-Werror` it is not possible to compile this way. 

In `matrix.c` `memset` is used like this. I fixed the problem by multiplying the fieldsize with `sizeof(matrix_row_t)`.